### PR TITLE
Change queue.handler to send null if the queue has no errors

### DIFF
--- a/firebase-util.js
+++ b/firebase-util.js
@@ -4113,7 +4113,7 @@ Queue.prototype = {
 
   handler: function(fn, context) {
     this._runOrStore(function() {
-      fn.apply(context, this.getErrors());
+      fn.apply(context, this.hasErrors()? this.getErrors() : [null]);
     });
     return this;
   },


### PR DESCRIPTION
This will make Firebase Util compatible with AngularFire, if queue.handler sends undefined instead of null AngularFire won't trigger the callbacks.
